### PR TITLE
Allow region to be filtered.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -423,7 +423,7 @@ function get_aws_sdk() {
 	}
 
 	$params = [
-		'region'  => 'us-east-1',
+		'region'  => apply_filters( 'hm.acm.region', 'us-east-1' ),
 		'version' => 'latest',
 	];
 


### PR DESCRIPTION
Some projects may need to use a region that's not `us-east-1` so allow for filtering of the region.