### PR TITLE
Create CloudFront Function and Origin Request Policy

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -2,10 +2,14 @@
 
 namespace HM\ACM\Admin;
 
+use function HM\ACM\get_cloudfront_function_arn;
+use function HM\ACM\get_cloudfront_origin_request_policy_id;
 use function HM\ACM\get_suggested_domains;
 use function HM\ACM\has_certificate;
 use function HM\ACM\create_certificate;
 use Exception;
+use function HM\ACM\has_cloudfront_function;
+use function HM\ACM\has_cloudfront_origin_request_policy;
 use function HM\ACM\has_verified_certificate;
 use function HM\ACM\get_certificate;
 use function HM\ACM\refresh_certificate;
@@ -127,6 +131,14 @@ function admin_page() {
 			<h4><?php printf( esc_html__( 'HTTPS Certificate: %1$s (%2$s)', 'hm-acm' ), implode( ', ', $certificate['SubjectAlternativeNames'] ),  $certificate['Status'] ) ?></h4>
 			<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-certificate' ), 'hm-acm-unlink-certificate' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
 		<?php endif ?>
+		<?php if ( has_cloudfront_function() ) : ?>
+			<h4><?php printf( esc_html__( 'CDN Function: %s', 'hm-acm' ), get_cloudfront_function_arn() ) ?></h4>
+		<?php endif ?>
+
+		<?php if ( has_cloudfront_origin_request_policy() ) : ?>
+			<h4><?php printf( esc_html__( 'CDN Request Policy: %s', 'hm-acm' ), get_cloudfront_origin_request_policy_id() ) ?></h4>
+		<?php endif ?>
+
 		<?php if ( has_cloudfront_distribution() ) : ?>
 			<?php
 			$distribution = get_cloudfront_distribution();

--- a/inc/cli/class-acm.php
+++ b/inc/cli/class-acm.php
@@ -15,6 +15,7 @@ use function HM\ACM\create_certificate;
 use function HM\ACM\create_cloudfront_distribution;
 use function HM\ACM\get_suggested_domains;
 use function HM\ACM\has_certificate;
+use function HM\ACM\has_cloudfront_distribution;
 use function HM\ACM\has_verified_certificate;
 use function HM\ACM\refresh_certificate;
 use function HM\ACM\unlink_certificate;
@@ -396,6 +397,13 @@ class Acm {
 	 * @return boolean
 	 */
 	private function create_cloudfront( int $site_id ): bool {
+		if ( has_cloudfront_distribution() ) {
+			if ( $this->verbose ) {
+				WP_CLI::success( sprintf( 'Site %d already has a CloudFront distribution.', $site_id ) );
+			}
+			return true;
+		}
+
 		if ( ! has_certificate() ) {
 			if ( $this->verbose ) {
 				WP_CLI::warning( sprintf( 'Site %d does not have an SSL certificate so CloudFront distribution cannot be created.', $site_id ) );

--- a/inc/cli/class-acm.php
+++ b/inc/cli/class-acm.php
@@ -396,6 +396,13 @@ class Acm {
 	 * @return boolean
 	 */
 	private function create_cloudfront( int $site_id ): bool {
+		if ( ! has_certificate() ) {
+			if ( $this->verbose ) {
+				WP_CLI::warning( sprintf( 'Site %d does not have an SSL certificate so CloudFront distribution cannot be created.', $site_id ) );
+			}
+			return false;
+		}
+
 		if ( ! has_verified_certificate() ) {
 			if ( $this->verbose ) {
 				WP_CLI::warning( sprintf( 'Site %d does not have a verified ACM SSL certificate so CloudFront distribution cannot be created.', $site_id ) );

--- a/inc/cli/class-acm.php
+++ b/inc/cli/class-acm.php
@@ -19,6 +19,7 @@ use function HM\ACM\has_cloudfront_distribution;
 use function HM\ACM\has_verified_certificate;
 use function HM\ACM\refresh_certificate;
 use function HM\ACM\unlink_certificate;
+use function HM\ACM\unlink_cloudfront_distribution;
 
 /**
  * Class for registering ACM specific WP-CLI commands.
@@ -222,6 +223,9 @@ class Acm {
 							case 'create-cloudfront':
 								$result = $this->create_cloudfront( $site_id );
 								break;
+							case 'delete-cloudfront':
+								$result = $this->delete_cloudfront( $site_id );
+								break;
 							default:
 								break;
 						}
@@ -386,6 +390,25 @@ class Acm {
 		}
 
 		unlink_certificate(); // This just removes the option in WP and allows for another cert to be requested.
+
+		return true;
+	}
+
+	/**
+	 * Delete CloudFront distribution for a site.
+	 *
+	 * @param int $site_id The ID of the site.
+	 * @return boolean
+	 */
+	private function delete_cloudfront( int $site_id ): bool {
+		if ( ! has_cloudfront_distribution() ) {
+			if ( $this->verbose ) {
+				WP_CLI::warning( sprintf( 'Site %d does not have a CloudFront distribution so nothing to delete.', $site_id ) );
+			}
+			return false;
+		}
+
+		unlink_cloudfront_distribution(); // This just removes the option in WP and allows for another CloudFront distribution to be created and linked.
 
 		return true;
 	}

--- a/inc/cli/class-acm.php
+++ b/inc/cli/class-acm.php
@@ -92,7 +92,7 @@ class Acm {
 			WP_CLI::error( 'An action is required.' );
 		}
 
-		if ( ! in_array( $this->action, [ 'create-cert', 'verify-cert', 'delete-cert', 'create-cloudfront' ], true ) ) {
+		if ( ! in_array( $this->action, [ 'create-cert', 'verify-cert', 'delete-cert', 'create-cloudfront', 'delete-cloudfront' ], true ) ) {
 			WP_CLI::error( 'Invalid action provided.' );
 		}
 

--- a/inc/cli/class-acm.php
+++ b/inc/cli/class-acm.php
@@ -146,6 +146,9 @@ class Acm {
 	 * [--exclude=<site-id>]
 	 * : Comma separated list of IDs of the sites to exclude from the action. Useful if you want the command to run network wide but exclude for example main site.
 	 *
+	 * [--rate=<rate>]
+	 * : How many sites to process at a time before sleeping for 1 second. Default is 5.
+	 *
 	 * [--network]
 	 * : Whether to perform the action on all sites on the network.
 	 *
@@ -184,9 +187,11 @@ class Acm {
 					break;
 				}
 
+				$rate = $assoc_args['rate'] ? intval( $assoc_args['rate'] ) : 5; // How many sites to process at a time before sleeping for 1 second.
+
 				for ( $i = 0; $i < count( $query->sites ); $i++ ) {
-					if ( $i % 5 === 0 ) {
-						// Sleep for 1 second every 5 sites to avoid rate limiting.
+					if ( $i % $rate === 0 ) {
+						// Sleep for 1 second every X sites to avoid rate limiting.
 						sleep( 1 );
 					}
 

--- a/inc/cloudfront-function.js
+++ b/inc/cloudfront-function.js
@@ -1,0 +1,14 @@
+function handler(event) {
+    var request = event.request;
+    var headers = request.headers;
+
+    // Check if the Host header exists
+    if (headers.host) {
+        // Copy the Host header value to the new x-original-host header (lowercase)
+        headers['x-original-host'] = {
+            value: headers.host.value
+        };
+    }
+
+    return request;
+}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -392,7 +392,10 @@ function create_cloudfront_origin_request_policy() : string {
 			'HeadersConfig' => [
 				'HeaderBehavior' => 'allExcept',
 				'Headers' => [
-					'Host',
+					'Quantity' => 1,
+					'Items' => [
+						'Host',
+					],
 				],
 			],
 			'QueryStringsConfig' => [

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -390,7 +390,10 @@ function create_cloudfront_origin_request_policy() : string {
 			'Comment' => 'HM-ACM origin request policy',
 			'Name' => $name,
 			'HeadersConfig' => [
-				'HeaderBehavior' => 'allViewer',
+				'HeaderBehavior' => 'allExcept',
+				'Headers' => [
+					'Host',
+				],
 			],
 			'QueryStringsConfig' => [
 				'QueryStringBehavior' => 'all',


### PR DESCRIPTION
This will create a cloudfront function and request policy along with each distribution, as we're limited on the amount of associations.

We _also_ have total limits on policies and functions, so we will likley need to follow this up with being able to link mulitple distributions to a single policy and function, and batch it every 100.
