### PR TITLE
Update config on certificate change

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -21,6 +21,7 @@ use function HM\ACM\refresh_cloudfront_distribution;
 use function HM\ACM\update_cloudfront_distribution_config;
 use function HM\ACM\unlink_certificate;
 use function HM\ACM\unlink_cloudfront_distribution;
+use function HM\ACM\distribution_matches_certificate;
 
 function bootstrap() {
 	add_submenu_page( 'tools.php', __( 'HTTPS Certificate', 'hm-acm' ), __( 'HTTPS Certificate', 'hm-acm' ), 'manage_options', 'hm-acm', __NAMESPACE__ . '\\admin_page' );
@@ -169,6 +170,11 @@ function admin_page() : void {
 			$distribution = get_cloudfront_distribution();
 			?>
 			<h4><?php printf( esc_html__( 'CDN Distribution: %s', 'hm-acm' ), $distribution['Id'] ) ?></h4>
+
+			<?php if( ! distribution_matches_certificate() ): ?>
+				<div class="notice notice-warning notice-alt"><p><?php esc_html_e( 'Warning: Your distribution is not using the linked certificate. Please update your config (below).', 'hm-acm' ) ?></p></div>
+			<?php endif ?>
+
 			<?php if ( $show_unlink_distribution ): ?>
 				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-cloudfront-distribution' ), 'hm-acm-unlink-cloudfront-distribution' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
 			<?php endif ?>

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -116,7 +116,12 @@ function on_unlink_cloudfront_distribution() {
 	exit;
 }
 
-function admin_page() {
+/**
+ * Display the admin page content to administer certificate setup.
+ *
+ * @return void
+ */
+function admin_page() : void {
 	?>
 	<div class="wrap">
 		<h1><?php _e( 'HTTPS Certificate', 'hm-acm' ) ?></h1>

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -126,6 +126,22 @@ function on_unlink_cloudfront_distribution() {
  * @return void
  */
 function admin_page() : void {
+
+	/**
+	* Determine whether or not to show the unlink certificate button.
+	*
+	* @param bool $show_unlink_certificate True if the unlink certificate button should be shown, otherwise false.
+	*/
+	$show_unlink_certificate = apply_filters( 'hm.acm.show_unlink_certificate', true );
+
+	/**
+	* Determine whether or not to show the unlink distribution button.
+	*
+	* @param bool $show_unlink_distribution True if the unlink certificate button should be shown, otherwise false.
+	*/
+	$show_unlink_distribution= apply_filters( 'hm.acm.show_unlink_distribution', true );
+
+
 	?>
 	<div class="wrap">
 		<h1><?php _e( 'HTTPS Certificate', 'hm-acm' ) ?></h1>
@@ -134,7 +150,11 @@ function admin_page() : void {
 			$certificate = get_certificate();
 			?>
 			<h4><?php printf( esc_html__( 'HTTPS Certificate: %1$s (%2$s)', 'hm-acm' ), implode( ', ', $certificate['SubjectAlternativeNames'] ),  $certificate['Status'] ) ?></h4>
-			<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-certificate' ), 'hm-acm-unlink-certificate' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
+
+			<?php if ( $show_unlink_certificate ): ?>
+				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-certificate' ), 'hm-acm-unlink-certificate' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
+			<?php endif ?>
+
 		<?php endif ?>
 		<?php if ( has_cloudfront_function() ) : ?>
 			<h4><?php printf( esc_html__( 'CDN Function: %s', 'hm-acm' ), get_cloudfront_function_arn() ) ?></h4>
@@ -149,7 +169,9 @@ function admin_page() : void {
 			$distribution = get_cloudfront_distribution();
 			?>
 			<h4><?php printf( esc_html__( 'CDN Distribution: %s', 'hm-acm' ), $distribution['Id'] ) ?></h4>
-			<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-cloudfront-distribution' ), 'hm-acm-unlink-cloudfront-distribution' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
+			<?php if ( $show_unlink_distribution ): ?>
+				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-cloudfront-distribution' ), 'hm-acm-unlink-cloudfront-distribution' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
+			<?php endif ?>
 			<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'update-cloudfront-distribution-config' ), 'hm-acm-update-cloudfront-distribution-config' ) ) ?>" class="button button-secondary">Update Config</a>
 			<p><?php esc_html_e( 'Please update the following DNS records to your domain(s) to activate HTTPS. If you want to support HTTPS on the root of your domain, you need to use AWS Route 53 with an "ALIAS" recording point the cloudfront domain listed below.' ) ?></p>
 			<table class="wp-list-table widefat fixed striped">

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -122,6 +122,46 @@ function on_unlink_cloudfront_distribution() {
 }
 
 /**
+ * Display details of the certificate in an accordion to aid debugging.
+ *
+ * @return void
+ */
+function display_certificate_details() : void {
+
+	if( ! has_certificate() ) {
+		return;
+	}
+
+	printf(
+		'<details><summary>%s</summary><pre><code>%s</code></pre></details>',
+		esc_html__( 'Certificate Details', 'hm-acm' ),
+		esc_html( get_certificate() )
+
+	);
+}
+
+/**
+ * Display details of the distribution in an accordion to aid debugging.
+ *
+ * @return void
+ */
+function display_cloudfront_distribution_details() : void {
+
+	$distribution = get_cloudfront_distribution();
+
+	if( empty( $distribution ) ) {
+		return;
+	}
+
+	printf(
+		'<details><summary>%s</summary><pre><code>%s</code></pre></details>',
+		esc_html__( 'Certificate Details', 'hm-acm' ),
+		esc_html( $distribution )
+
+	);
+}
+
+/**
  * Display the admin page content to administer certificate setup.
  *
  * @return void
@@ -155,6 +195,8 @@ function admin_page() : void {
 			<?php if ( $show_unlink_certificate ): ?>
 				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-certificate' ), 'hm-acm-unlink-certificate' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
 			<?php endif ?>
+
+			<?php display_certificate_details(); ?>
 
 		<?php endif ?>
 		<?php if ( has_cloudfront_function() ) : ?>
@@ -200,6 +242,8 @@ function admin_page() : void {
 					<?php endforeach ?>
 				</tbody>
 			</table>
+
+			<?php display_cloudfront_distribution_details(); ?>
 		<?php endif ?>
 		<?php if ( ! has_certificate() ) : ?>
 			<h2><?php esc_html_e( 'Step 1: Request HTTPS Certificate', 'hm-acm' ) ?></h2>
@@ -210,7 +254,7 @@ function admin_page() : void {
 					<input type="text" class="widefat" value="<?php echo esc_attr( implode( ', ', get_suggested_domains() ) ) ?>" name="domains" />
 				</p>
 				<p class="description">
-					<?php _e( 'Seperate multiple domains with a comma.' ) ?>
+					<?php _e( 'Separate multiple domains with a comma.' ) ?>
 				</p>
 				<p class="submit">
 					<input type="submit" class="button-primary" value="<?php esc_attr_e( 'Request Certificate', 'hm-acm' ) ?>" />

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -133,9 +133,9 @@ function display_certificate_details() : void {
 	}
 
 	printf(
-		'<details><summary>%s</summary><pre><code>%s</code></pre></details>',
+		'<details><summary><strong>%s</strong></summary><pre><code>%s</code></pre></details><br/>',
 		esc_html__( 'Certificate Details', 'hm-acm' ),
-		esc_html( get_certificate() )
+		esc_html( print_r( get_certificate(), true ) )
 
 	);
 }
@@ -154,9 +154,9 @@ function display_cloudfront_distribution_details() : void {
 	}
 
 	printf(
-		'<details><summary>%s</summary><pre><code>%s</code></pre></details>',
-		esc_html__( 'Certificate Details', 'hm-acm' ),
-		esc_html( $distribution )
+		'<details><summary><strong>%s</strong></summary><pre><code>%s</code></pre></details><br/>',
+		esc_html__( 'Cloudfront Distribution Details', 'hm-acm' ),
+		esc_html( print_r( $distribution, true ) )
 
 	);
 }
@@ -192,11 +192,11 @@ function admin_page() : void {
 			?>
 			<h4><?php printf( esc_html__( 'HTTPS Certificate: %1$s (%2$s)', 'hm-acm' ), implode( ', ', $certificate['SubjectAlternativeNames'] ),  $certificate['Status'] ) ?></h4>
 
+			<?php display_certificate_details(); ?>
+
 			<?php if ( $show_unlink_certificate ): ?>
 				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hm-acm-action', 'unlink-certificate' ), 'hm-acm-unlink-certificate' ) ) ?>" class="button button-secondary"><?php esc_html_e( 'Unlink', 'hm-acm' ) ?></a>
 			<?php endif ?>
-
-			<?php display_certificate_details(); ?>
 
 		<?php endif ?>
 		<?php if ( has_cloudfront_function() ) : ?>
@@ -212,6 +212,8 @@ function admin_page() : void {
 			$distribution = get_cloudfront_distribution();
 			?>
 			<h4><?php printf( esc_html__( 'CDN Distribution: %s', 'hm-acm' ), $distribution['Id'] ) ?></h4>
+
+			<?php display_cloudfront_distribution_details(); ?>
 
 			<?php if( ! distribution_matches_certificate() ): ?>
 				<div class="notice notice-warning notice-alt"><p><?php esc_html_e( 'Warning: Your distribution is not using the linked certificate. Please update your config (below).', 'hm-acm' ) ?></p></div>
@@ -243,7 +245,6 @@ function admin_page() : void {
 				</tbody>
 			</table>
 
-			<?php display_cloudfront_distribution_details(); ?>
 		<?php endif ?>
 		<?php if ( ! has_certificate() ) : ?>
 			<h2><?php esc_html_e( 'Step 1: Request HTTPS Certificate', 'hm-acm' ) ?></h2>

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -178,7 +178,7 @@ function admin_page() : void {
 	/**
 	* Determine whether or not to show the unlink distribution button.
 	*
-	* @param bool $show_unlink_distribution True if the unlink certificate button should be shown, otherwise false.
+	* @param bool $show_unlink_distribution True if the unlink distribution button should be shown, otherwise false.
 	*/
 	$show_unlink_distribution= apply_filters( 'hm.acm.show_unlink_distribution', true );
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -4,18 +4,38 @@ namespace HM\ACM;
 
 use Exception;
 
+/**
+ * Check whether the site has a certificate set as an option.
+ *
+ * @return boolean True if the certificate is set.
+ */
 function has_certificate() : bool {
 	return (bool) get_option( 'hm-acm-certificate' );
 }
 
+/**
+ * Check whether the site's certificate has been verified.
+ *
+ * @return boolean True if the certificate is verified.
+ */
 function has_verified_certificate() {
 	return get_certificate()['Status'] === 'ISSUED';
 }
 
+/**
+ * Get the certificate details for the site.
+ *
+ * @return array An array of certificate details, derived from \AWS\Result.
+ */
 function get_certificate() : array {
 	return get_option( 'hm-acm-certificate' );
 }
 
+/**
+ * Refresh the certificate from AWS and update the site option to match, or remove it on failure.
+ *
+ * @return void
+ */
 function refresh_certificate() {
 	try {
 		$certificate = get_aws_acm_client()->describeCertificate([
@@ -72,6 +92,12 @@ function create_certificate( array $domains ) : array {
 	return $certificate;
 }
 
+/**
+ * Unlink the certificate from the site by deleting the option.
+ * Note this does not delete the certificate from AWS.
+ *
+ * @return void
+ */
 function unlink_certificate() {
 	delete_option( 'hm-acm-certificate' );
 }
@@ -107,6 +133,11 @@ function create_cloudfront_distribution() {
 	update_option( 'hm-cloudfront-distribution', $result['Distribution'] );
 }
 
+/**
+ * Update the existing Cloudfront distribution.
+ *
+ * @return void
+ */
 function update_cloudfront_distribution_config() {
 	$current_distribution = get_aws_cloudfront_client()->getDistribution([
 		'Id' => get_cloudfront_distribution()['Id'],
@@ -253,6 +284,11 @@ function get_aws_cloudfront_client() {
 	return get_aws_sdk()->createCloudFront();
 }
 
+/**
+ * Get the AWS instance for the network.
+ *
+ * @return \AWS\Sdk AWS SDK class for the network.
+ */
 function get_aws_sdk() {
 	static $sdk;
 	if ( $sdk ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -32,6 +32,23 @@ function get_certificate() : array {
 }
 
 /**
+ * Check whether the distribution is using the linked certificate.
+ *
+ * @return bool True if certificates match, else false.
+ */
+function distribution_matches_certificate() : bool {
+	$certificate = get_certificate();
+	$distribution = get_cloudfront_distribution();
+
+	if( empty( $certificate ) || empty( $distribution ) ) {
+		return false;
+	}
+
+	return $certificate['CertificateArn'] === ( $distribution['DistributionConfig']['ViewerCertificate']['ACMCertificateArn'] ?? false );
+
+}
+
+/**
  * Refresh the certificate from AWS and update the site option to match, or remove it on failure.
  *
  * @return void

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,12 +37,13 @@ function get_certificate() : array {
  * @return bool True if certificates match, else false.
  */
 function distribution_matches_certificate() : bool {
-	$certificate = get_certificate();
-	$distribution = get_cloudfront_distribution();
 
-	if( empty( $certificate ) || empty( $distribution ) ) {
+	if( ! has_certificate() || ! has_cloudfront_distribution() ) {
 		return false;
 	}
+
+	$certificate = get_certificate();
+	$distribution = get_cloudfront_distribution();
 
 	return $certificate['CertificateArn'] === ( $distribution['DistributionConfig']['ViewerCertificate']['ACMCertificateArn'] ?? false );
 


### PR DESCRIPTION
We have a site using HM-ACM which sometimes requires updating the certificate and Cloudfront distribution with new domains. This PR makes a few changes to improve this workflow:

- Added documentation for some functions.
- Allow showing/hiding of the unlink buttons for both certificates and distributions. In our use case, there's not a use case for unlinking the distribution and it's a more involved process to relink it (although I'd like to add the option to relink via a button as a followup). This avoids accidental clicks that can't be easily resolved from within the dashboard.
- Add a check for whether the Cloudfront distribution is using the correct certificate, and warning the user if not.
- Display the certificate and distribution details (within an accordion) to allow for easier debugging and checking that distributions/certificates match.

I've made this PR against #15, which I'm hoping we can also get merged and into a release. I have a couple of slightly more opinionated readability improvements as well, but I'll address those in a followup so they don't block this.