### PR TITLE
Use existing caller reference when updating a distribution

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -208,7 +208,7 @@ function get_cloudfront_distribution_config( $caller_reference = null ) : array 
 	$caller_reference = $caller_reference ?? site_url();
 
 	$config = [
-		'CallerReference' => site_url(),
+		'CallerReference' => $caller_reference,
 		'Aliases' => [
 			'Items' => $domains,
 			'Quantity' => count( $domains ),

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -178,7 +178,7 @@ function update_cloudfront_distribution_config() {
 	}
 
 	$result = get_aws_cloudfront_client()->updateDistribution( [
-		'DistributionConfig' => get_cloudfront_distribution_config(),
+		'DistributionConfig' => get_cloudfront_distribution_config( $current_distribution[ 'CallerReference' ] ),
 		'Id' => get_cloudfront_distribution()['Id'],
 		'IfMatch' => $current_distribution['ETag'],
 	] );
@@ -192,11 +192,20 @@ function unlink_cloudfront_distribution() {
 	delete_option( 'hm-cloudfront-origin-request-policy' );
 }
 
-function get_cloudfront_distribution_config() : array {
+/**
+ * Get the config for a Cloudfront distribution
+ *
+ * @param string|null $caller_reference The caller reference to pass to the distribution config.
+ * @return array The Cloudfront distribution config to pass to AWS.
+ */
+function get_cloudfront_distribution_config( $caller_reference = null ) : array {
 	$certificate = get_certificate();
 	$domains = array_unique( array_merge( [ $certificate['DomainName'] ], $certificate['SubjectAlternativeNames'] ) );
 	$cloudfront_function_arn = get_cloudfront_function_arn();
 	$origin_request_policy_id = get_cloudfront_origin_request_policy_id();
+
+	// If we haven't passed an explicit caller reference, then use the site url.
+	$caller_reference = $caller_reference ?? site_url();
 
 	$config = [
 		'CallerReference' => site_url(),

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -177,8 +177,10 @@ function update_cloudfront_distribution_config() {
 		create_cloudfront_origin_request_policy();
 	}
 
+	$caller_reference = $current_distribution[ 'Distribution' ][ 'DistributionConfig' ][ 'CallerReference' ];
+
 	$result = get_aws_cloudfront_client()->updateDistribution( [
-		'DistributionConfig' => get_cloudfront_distribution_config( $current_distribution[ 'CallerReference' ] ),
+		'DistributionConfig' => get_cloudfront_distribution_config( $caller_reference ),
 		'Id' => get_cloudfront_distribution()['Id'],
 		'IfMatch' => $current_distribution['ETag'],
 	] );


### PR DESCRIPTION
Change caller reference to use the existing value when updating, since this cannot be changed.

As per https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateDistribution.html#API_UpdateDistribution_RequestSyntax, the caller reference cannot be changed in a request to update the distribution - this causes the request to fail.

This usually isn't an issue, however if the site url has changed (in the case I've been investigating, switching from http to https), then the existing distribution is unable to be updated.