### PR TITLE
Update minimum TLS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The plugin includes a CLI command `hm-acm` which allows for executing some actio
 - **create-cert** which will create an ACM certificate given a comma separated list of domains. If no domains are supplied via the command then they'll be attempted to be retrieved via the suggested domains function allows for filtering the domains via other plugins.
 - **verify-cert** which will refresh the details of an ACM certificate in WordPress. Helps check if the records to validate the cert have been added.
 - **delete-cert** which will unlink an ACM certificate in WordPress from a site.
-- **create-cloudfront** which will create a CloudFront distribution provided the site has a verified certificate.
+- **create-cloudfront**, **delete-cloudfront** and **update-cloudfront** which will create, delete or update respectively a CloudFront distribution provided the site has a verified certificate.
 
 Example usage:
 

--- a/inc/cli/class-acm.php
+++ b/inc/cli/class-acm.php
@@ -20,6 +20,7 @@ use function HM\ACM\has_verified_certificate;
 use function HM\ACM\refresh_certificate;
 use function HM\ACM\unlink_certificate;
 use function HM\ACM\unlink_cloudfront_distribution;
+use function HM\ACM\update_cloudfront_distribution_config;
 
 /**
  * Class for registering ACM specific WP-CLI commands.
@@ -92,7 +93,16 @@ class Acm {
 			WP_CLI::error( 'An action is required.' );
 		}
 
-		if ( ! in_array( $this->action, [ 'create-cert', 'verify-cert', 'delete-cert', 'create-cloudfront', 'delete-cloudfront' ], true ) ) {
+		$valid_actions = [
+			'create-cert',
+			'verify-cert',
+			'delete-cert',
+			'create-cloudfront',
+			'delete-cloudfront',
+			'update-cloudfront',
+		];
+
+		if ( ! in_array( $this->action, $valid_actions, true ) ) {
 			WP_CLI::error( 'Invalid action provided.' );
 		}
 
@@ -225,6 +235,9 @@ class Acm {
 								break;
 							case 'delete-cloudfront':
 								$result = $this->delete_cloudfront( $site_id );
+								break;
+							case 'update-cloudfront':
+								$result = $this->update_cloudfront( $site_id );
 								break;
 							default:
 								break;
@@ -446,6 +459,46 @@ class Acm {
 		} catch ( Exception $e ) {
 			if ( $this->verbose ) {
 				WP_CLI::error( sprintf( 'Failed to create CloudFront distribution for site %d. Error: %s', $site_id, $e->getMessage() ) );
+			}
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Update CloudFront distribution for a site.
+	 *
+	 * @param int $site_id The ID of the site.
+	 * @return boolean
+	 */
+	private function update_cloudfront( int $site_id ): bool {
+		if ( ! has_cloudfront_distribution() ) {
+			if ( $this->verbose ) {
+				WP_CLI::warning( sprintf( 'Site %d does not have a CloudFront distribution so nothing to update.', $site_id ) );
+			}
+			return false;
+		}
+
+		if ( ! has_certificate() ) {
+			if ( $this->verbose ) {
+				WP_CLI::warning( sprintf( 'Site %d does not have an ACM SSL certificate so CloudFront distribution cannot be updated.', $site_id ) );
+			}
+			return false;
+		}
+
+		if ( ! has_verified_certificate() ) {
+			if ( $this->verbose ) {
+				WP_CLI::warning( sprintf( 'Site %d does not have a verified ACM SSL certificate so CloudFront distribution cannot be updated.', $site_id ) );
+			}
+			return false;
+		}
+
+		try {
+			update_cloudfront_distribution_config();
+		} catch ( Exception $e ) {
+			if ( $this->verbose ) {
+				WP_CLI::error( sprintf( 'Failed to update CloudFront distribution for site %d. Error: %s', $site_id, $e->getMessage() ) );
 			}
 			return false;
 		}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -301,7 +301,7 @@ function get_cloudfront_distribution_config( $caller_reference = null ) : array 
 		'ViewerCertificate' => [
 			'ACMCertificateArn' => $certificate['CertificateArn'],
 			'SSLSupportMethod' => 'sni-only',
-			'MinimumProtocolVersion' => 'TLSv1',
+			'MinimumProtocolVersion' => 'TLSv1.2_2025',
 		],
 		'HttpVersion' => 'http2and3',
 		'IsIPV6Enabled' => true,


### PR DESCRIPTION
TLS 1.0 and 1.1 are now deprecated so update the minimum protocol version to TLSv1.2_2025 so Cloudfront distributions enforce a more secure and widely supported protocol.