### PR TITLE
Support configurable WAF Web ACL for CloudFront distributions

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -178,9 +178,16 @@ function update_cloudfront_distribution_config() {
 	}
 
 	$caller_reference = $current_distribution[ 'Distribution' ][ 'DistributionConfig' ][ 'CallerReference' ];
+	$config = get_cloudfront_distribution_config( $caller_reference );
+
+	// Preserve the existing WebACLId from the live distribution if no
+	// explicit WAF Web ACL has been configured via constant.
+	if ( ! defined( 'HM_ACM_WAF_WEB_ACL_ID' ) ) {
+		$config['WebACLId'] = $current_distribution['Distribution']['DistributionConfig']['WebACLId'] ?? '';
+	}
 
 	$result = get_aws_cloudfront_client()->updateDistribution( [
-		'DistributionConfig' => get_cloudfront_distribution_config( $caller_reference ),
+		'DistributionConfig' => $config,
 		'Id' => get_cloudfront_distribution()['Id'],
 		'IfMatch' => $current_distribution['ETag'],
 	] );
@@ -311,7 +318,7 @@ function get_cloudfront_distribution_config( $caller_reference = null ) : array 
 			'Prefix' => '',
 			'Bucket' => '',
 		],
-		'WebACLId' => '',
+		'WebACLId' => defined( 'HM_ACM_WAF_WEB_ACL_ID' ) ? HM_ACM_WAF_WEB_ACL_ID : '',
 		'Restrictions' => [
 			'GeoRestriction' => [
 				'Items' => [],


### PR DESCRIPTION
## Summary

- Add `HM_ACM_WAF_WEB_ACL_ID` constant support so CloudFront distributions are created with a WAF Web ACL attached when the constant is defined
- On distribution updates, preserve the existing `WebACLId` from the live distribution config when no constant is configured, preventing `update-cloudfront` operations from stripping manually-applied WAF associations

## Context

The `WebACLId` was previously hardcoded to `''` in `get_cloudfront_distribution_config()`. This meant:
- New distributions were always created without WAF
- Updates to existing distributions (e.g. TLS version changes) would strip any WAF Web ACL that had been manually associated

## Usage

Define the constant in your application config:

```php
define( 'HM_ACM_WAF_WEB_ACL_ID', 'arn:aws:wafv2:us-east-1:ACCOUNT_ID:global/webacl/NAME/ID' );
```

## Test plan

- [ ] Verify `update-cloudfront` preserves existing WebACLId when constant is not defined
- [ ] Verify `update-cloudfront` uses constant value when `HM_ACM_WAF_WEB_ACL_ID` is defined
- [ ] Verify `create-cloudfront` uses constant value when defined
- [ ] Verify `create-cloudfront` uses empty string when constant is not defined (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)